### PR TITLE
test: add GPL check for PyPi packages for Linux

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -24,15 +24,15 @@ jobs:
 
       - name: Running Bandit
         if: ${{ matrix.os == 'ubuntu-18.04' }}
-        run: python -m bandit -r ./ -f screen |& tee bandit.log
+        run: python -m bandit -r ./ -f screen
           
       - name: Running PEP checks
         if: ${{ matrix.os == 'ubuntu-18.04' }}
-        run: python -m flake8 ./ --config=setup.cfg --show-source |& tee flake8.log
+        run: python -m flake8 ./ --config=setup.cfg --show-source
 
       - name: Running MyPy checks
         if: ${{ matrix.os == 'ubuntu-18.04' }}
-        run: python -m mypy ./ --config-file ./setup.cfg --show-error-context --show-column-numbers --pretty |& tee mypy.log
+        run: python -m mypy ./ --config-file ./setup.cfg --show-error-context --show-column-numbers --pretty
 
       - name: Running pytest (not Docker image tests)
         if: ${{ always() }}
@@ -44,7 +44,4 @@ jobs:
         with:
           name: codestyle_checks
           path: |
-            ./bandit.log
-            ./flake8.log
-            ./mypy.log
             ./utils_unittests.html

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ docstring-convention = google
 ignore = DAR101, DAR201, DAR401, D107, D415, I201, T001, S404, S603, G004, B009, E800
 enable-extensions=G
 per-file-ignores =
-    tests/*: D100,D101,D102,D104
+    tests/*: D100,D101,D102,D104,S108
     tests/conftest.py: D100,D101,D102,D103,D104
 
 [pydocstyle]

--- a/tests/functional/demos/test_demos_linux_runtime.py
+++ b/tests/functional/demos/test_demos_linux_runtime.py
@@ -8,10 +8,9 @@ import pytest
 
 @pytest.mark.usefixtures('_is_image_os', '_is_distribution', '_is_package_url_specified')
 @pytest.mark.parametrize('_is_image_os', ['ubuntu18', 'ubuntu20', 'centos7'], indirect=True)
-@pytest.mark.parametrize('_is_distribution', ['runtime'], indirect=True)
-class TestDemosLinuxRuntime:
-    def test_detection_ssd_python_cpu(self, tester, image, mount_root, sample_name):
-        dev_root = (pathlib.Path(mount_root) / 'openvino_dev').iterdir().__next__()
+@pytest.mark.parametrize('_is_distribution', ['data_runtime'], indirect=True)
+class TestDemosLinuxDataRuntime:
+    def test_detection_ssd_python_cpu(self, tester, image, dev_root, sample_name):
         kwargs = {
             'mem_limit': '3g',
             'volumes': {
@@ -39,8 +38,7 @@ class TestDemosLinuxRuntime:
         )
 
     @pytest.mark.gpu
-    def test_detection_ssd_python_gpu(self, tester, image, mount_root, sample_name):
-        dev_root = (pathlib.Path(mount_root) / 'openvino_dev').iterdir().__next__()
+    def test_detection_ssd_python_gpu(self, tester, image, dev_root, sample_name):
         kwargs = {
             'devices': ['/dev/dri:/dev/dri'],
             'mem_limit': '3g',
@@ -69,8 +67,7 @@ class TestDemosLinuxRuntime:
         )
 
     @pytest.mark.vpu
-    def test_detection_ssd_python_vpu(self, tester, image, mount_root, sample_name):
-        dev_root = (pathlib.Path(mount_root) / 'openvino_dev').iterdir().__next__()
+    def test_detection_ssd_python_vpu(self, tester, image, dev_root, sample_name):
         kwargs = {
             'device_cgroup_rules': ['c 189:* rmw'],
             'mem_limit': '3g',
@@ -102,8 +99,7 @@ class TestDemosLinuxRuntime:
         )
 
     @pytest.mark.hddl
-    def test_detection_ssd_python_hddl(self, tester, image, mount_root, sample_name):
-        dev_root = (pathlib.Path(mount_root) / 'openvino_dev').iterdir().__next__()
+    def test_detection_ssd_python_hddl(self, tester, image, dev_root, sample_name):
         kwargs = {
             'devices': ['/dev/ion:/dev/ion'],
             'mem_limit': '3g',
@@ -132,8 +128,12 @@ class TestDemosLinuxRuntime:
              ], self.test_detection_ssd_python_hddl.__name__, **kwargs,
         )
 
-    def test_segmentation_python_cpu(self, tester, image, mount_root):
-        dev_root = (pathlib.Path(mount_root) / 'openvino_dev').iterdir().__next__()
+
+@pytest.mark.usefixtures('_is_image_os', '_is_distribution', '_is_package_url_specified')
+@pytest.mark.parametrize('_is_image_os', ['ubuntu18', 'ubuntu20', 'centos7'], indirect=True)
+@pytest.mark.parametrize('_is_distribution', ['runtime'], indirect=True)
+class TestDemosLinuxRuntime:
+    def test_segmentation_python_cpu(self, tester, image, dev_root):
         kwargs = {
             'mem_limit': '3g',
             'volumes': {
@@ -163,8 +163,7 @@ class TestDemosLinuxRuntime:
         )
 
     @pytest.mark.gpu
-    def test_segmentation_python_gpu(self, tester, image, mount_root):
-        dev_root = (pathlib.Path(mount_root) / 'openvino_dev').iterdir().__next__()
+    def test_segmentation_python_gpu(self, tester, image, dev_root):
         kwargs = {
             'devices': ['/dev/dri:/dev/dri'],
             'mem_limit': '3g',
@@ -195,8 +194,7 @@ class TestDemosLinuxRuntime:
         )
 
     @pytest.mark.vpu
-    def test_segmentation_python_vpu(self, tester, image, mount_root):
-        dev_root = (pathlib.Path(mount_root) / 'openvino_dev').iterdir().__next__()
+    def test_segmentation_python_vpu(self, tester, image, dev_root):
         kwargs = {
             'device_cgroup_rules': ['c 189:* rmw'],
             'mem_limit': '3g',
@@ -231,8 +229,7 @@ class TestDemosLinuxRuntime:
 
     @pytest.mark.hddl
     @pytest.mark.xfail(reason='38557 issue')
-    def test_segmentation_python_hddl(self, tester, image, mount_root):
-        dev_root = (pathlib.Path(mount_root) / 'openvino_dev').iterdir().__next__()
+    def test_segmentation_python_hddl(self, tester, image, dev_root):
         kwargs = {
             'devices': ['/dev/ion:/dev/ion'],
             'mem_limit': '3g',

--- a/tests/functional/demos/test_demos_linux_runtime.py
+++ b/tests/functional/demos/test_demos_linux_runtime.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2019-2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-import pathlib
-
 import pytest
 
 

--- a/tests/functional/samples/test_samples_linux_runtime.py
+++ b/tests/functional/samples/test_samples_linux_runtime.py
@@ -19,8 +19,7 @@ def install_build_essential(image_os):
 @pytest.mark.parametrize('_is_image_os', ['ubuntu18', 'ubuntu20', 'centos7', 'centos8'], indirect=True)
 @pytest.mark.parametrize('_is_distribution', ['runtime'], indirect=True)
 class TestSamplesLinuxRuntime:
-    def test_hello_classification_cpp_cpu(self, tester, image, mount_root, image_os):
-        dev_root = (pathlib.Path(mount_root) / 'openvino_dev').iterdir().__next__()
+    def test_hello_classification_cpp_cpu(self, tester, image, dev_root, image_os):
         kwargs = {
             'mem_limit': '3g',
             'volumes': {
@@ -64,8 +63,7 @@ class TestSamplesLinuxRuntime:
         )
 
     @pytest.mark.gpu
-    def test_hello_classification_cpp_gpu(self, tester, image, mount_root, image_os):
-        dev_root = (pathlib.Path(mount_root) / 'openvino_dev').iterdir().__next__()
+    def test_hello_classification_cpp_gpu(self, tester, image, dev_root, image_os):
         kwargs = {
             'devices': ['/dev/dri:/dev/dri'],
             'mem_limit': '3g',
@@ -110,8 +108,7 @@ class TestSamplesLinuxRuntime:
         )
 
     @pytest.mark.vpu
-    def test_hello_classification_cpp_vpu(self, tester, image, mount_root, image_os):
-        dev_root = (pathlib.Path(mount_root) / 'openvino_dev').iterdir().__next__()
+    def test_hello_classification_cpp_vpu(self, tester, image, dev_root, image_os):
         kwargs = {
             'device_cgroup_rules': ['c 189:* rmw'],
             'mem_limit': '3g',
@@ -159,8 +156,7 @@ class TestSamplesLinuxRuntime:
         )
 
     @pytest.mark.hddl
-    def test_hello_classification_cpp_hddl(self, tester, image, mount_root, image_os):
-        dev_root = (pathlib.Path(mount_root) / 'openvino_dev').iterdir().__next__()
+    def test_hello_classification_cpp_hddl(self, tester, image, dev_root, image_os):
         kwargs = {
             'devices': ['/dev/ion:/dev/ion'],
             'mem_limit': '3g',
@@ -207,8 +203,7 @@ class TestSamplesLinuxRuntime:
 
     @pytest.mark.usefixtures('_min_product_version')
     @pytest.mark.parametrize('_min_product_version', ['2021.2'], indirect=True)
-    def test_hello_classification_cpp_fail(self, tester, image, mount_root, image_os, caplog):
-        dev_root = (pathlib.Path(mount_root) / 'openvino_dev').iterdir().__next__()
+    def test_hello_classification_cpp_fail(self, tester, image, dev_root, image_os, caplog):
         kwargs = {
             'mem_limit': '3g',
             'volumes': {
@@ -251,8 +246,7 @@ class TestSamplesLinuxRuntime:
         if 'Sample supports topologies with 1 output only' not in caplog.text:
             pytest.fail('Sample supports topologies with 1 output only')
 
-    def test_hello_reshape_cpp_cpu(self, tester, image, mount_root, image_os):
-        dev_root = (pathlib.Path(mount_root) / 'openvino_dev').iterdir().__next__()
+    def test_hello_reshape_cpp_cpu(self, tester, image, dev_root, image_os):
         kwargs = {
             'mem_limit': '3g',
             'volumes': {
@@ -292,8 +286,7 @@ class TestSamplesLinuxRuntime:
         )
 
     @pytest.mark.gpu
-    def test_hello_reshape_cpp_gpu(self, tester, image, mount_root, image_os):
-        dev_root = (pathlib.Path(mount_root) / 'openvino_dev').iterdir().__next__()
+    def test_hello_reshape_cpp_gpu(self, tester, image, dev_root, image_os):
         kwargs = {
             'devices': ['/dev/dri:/dev/dri'],
             'mem_limit': '3g',
@@ -334,8 +327,7 @@ class TestSamplesLinuxRuntime:
         )
 
     @pytest.mark.vpu
-    def test_hello_reshape_cpp_vpu(self, tester, image, mount_root, image_os):
-        dev_root = (pathlib.Path(mount_root) / 'openvino_dev').iterdir().__next__()
+    def test_hello_reshape_cpp_vpu(self, tester, image, dev_root, image_os):
         kwargs = {
             'device_cgroup_rules': ['c 189:* rmw'],
             'mem_limit': '3g',
@@ -379,8 +371,7 @@ class TestSamplesLinuxRuntime:
         )
 
     @pytest.mark.hddl
-    def test_hello_reshape_cpp_hddl(self, tester, image, mount_root, image_os):
-        dev_root = (pathlib.Path(mount_root) / 'openvino_dev').iterdir().__next__()
+    def test_hello_reshape_cpp_hddl(self, tester, image, dev_root, image_os):
         kwargs = {
             'devices': ['/dev/ion:/dev/ion'],
             'mem_limit': '3g',
@@ -421,8 +412,7 @@ class TestSamplesLinuxRuntime:
              ], self.test_hello_reshape_cpp_hddl.__name__, **kwargs,
         )
 
-    def test_object_detection_cpp_cpu(self, tester, image, mount_root, image_os):
-        dev_root = (pathlib.Path(mount_root) / 'openvino_dev').iterdir().__next__()
+    def test_object_detection_cpp_cpu(self, tester, image, dev_root, image_os):
         kwargs = {
             'mem_limit': '3g',
             'volumes': {
@@ -459,8 +449,7 @@ class TestSamplesLinuxRuntime:
         )
 
     @pytest.mark.gpu
-    def test_object_detection_cpp_gpu(self, tester, image, mount_root, image_os):
-        dev_root = (pathlib.Path(mount_root) / 'openvino_dev').iterdir().__next__()
+    def test_object_detection_cpp_gpu(self, tester, image, dev_root, image_os):
         kwargs = {
             'devices': ['/dev/dri:/dev/dri'],
             'mem_limit': '3g',
@@ -498,8 +487,7 @@ class TestSamplesLinuxRuntime:
         )
 
     @pytest.mark.vpu
-    def test_object_detection_cpp_vpu(self, tester, image, mount_root, image_os):
-        dev_root = (pathlib.Path(mount_root) / 'openvino_dev').iterdir().__next__()
+    def test_object_detection_cpp_vpu(self, tester, image, dev_root, image_os):
         kwargs = {
             'device_cgroup_rules': ['c 189:* rmw'],
             'mem_limit': '3g',
@@ -540,8 +528,7 @@ class TestSamplesLinuxRuntime:
         )
 
     @pytest.mark.hddl
-    def test_object_detection_cpp_hddl(self, tester, image, mount_root, image_os):
-        dev_root = (pathlib.Path(mount_root) / 'openvino_dev').iterdir().__next__()
+    def test_object_detection_cpp_hddl(self, tester, image, dev_root, image_os):
         kwargs = {
             'devices': ['/dev/ion:/dev/ion'],
             'mem_limit': '3g',
@@ -579,8 +566,7 @@ class TestSamplesLinuxRuntime:
              ], self.test_object_detection_cpp_hddl.__name__, **kwargs,
         )
 
-    def test_classification_async_cpp_cpu(self, tester, image, mount_root, image_os):
-        dev_root = (pathlib.Path(mount_root) / 'openvino_dev').iterdir().__next__()
+    def test_classification_async_cpp_cpu(self, tester, image, dev_root, image_os):
         kwargs = {
             'mem_limit': '3g',
             'volumes': {
@@ -624,8 +610,7 @@ class TestSamplesLinuxRuntime:
         )
 
     @pytest.mark.gpu
-    def test_classification_async_cpp_gpu(self, tester, image, mount_root, image_os):
-        dev_root = (pathlib.Path(mount_root) / 'openvino_dev').iterdir().__next__()
+    def test_classification_async_cpp_gpu(self, tester, image, dev_root, image_os):
         kwargs = {
             'devices': ['/dev/dri:/dev/dri'],
             'mem_limit': '3g',
@@ -670,8 +655,7 @@ class TestSamplesLinuxRuntime:
         )
 
     @pytest.mark.vpu
-    def test_classification_async_cpp_vpu(self, tester, image, mount_root, image_os):
-        dev_root = (pathlib.Path(mount_root) / 'openvino_dev').iterdir().__next__()
+    def test_classification_async_cpp_vpu(self, tester, image, dev_root, image_os):
         kwargs = {
             'devices': ['/dev/dri:/dev/dri'],
             'mem_limit': '3g',
@@ -719,8 +703,7 @@ class TestSamplesLinuxRuntime:
         )
 
     @pytest.mark.hddl
-    def test_classification_async_cpp_hddl(self, tester, image, mount_root, image_os):
-        dev_root = (pathlib.Path(mount_root) / 'openvino_dev').iterdir().__next__()
+    def test_classification_async_cpp_hddl(self, tester, image, dev_root, image_os):
         kwargs = {
             'devices': ['/dev/ion:/dev/ion'],
             'mem_limit': '3g',

--- a/tests/functional/samples/test_samples_linux_runtime.py
+++ b/tests/functional/samples/test_samples_linux_runtime.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2019-2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-import pathlib
-
 import pytest
 
 from utils.exceptions import FailedTest

--- a/tests/functional/test_pypi_deps.py
+++ b/tests/functional/test_pypi_deps.py
@@ -19,8 +19,8 @@ class TestPyPiDependencies:
             pypi_log_folder.mkdir()
         kwargs = {
             'volumes': {
-                root / 'tests' / 'resources' / 'pypi_deps': {'bind': '/tmp/pypi_deps', 'mode': 'rw'},
-                pypi_log_folder: {'bind': '/tmp/logs', 'mode': 'rw'},
+                root / 'tests' / 'resources' / 'pypi_deps': {'bind': '/tmp/pypi_deps', 'mode': 'rw'},  # nosec
+                pypi_log_folder: {'bind': '/tmp/logs', 'mode': 'rw'},  # nosec
             },
         }
         tester.test_docker_image(
@@ -49,8 +49,8 @@ class TestPyPiDependencies:
             pypi_log_folder.mkdir()
         kwargs = {
             'volumes': {
-                root / 'tests' / 'resources' / 'pypi_deps': {'bind': '/tmp/pypi_deps', 'mode': 'rw'},
-                pypi_log_folder: {'bind': '/tmp/logs', 'mode': 'rw'},
+                root / 'tests' / 'resources' / 'pypi_deps': {'bind': '/tmp/pypi_deps', 'mode': 'rw'},  # nosec
+                pypi_log_folder: {'bind': '/tmp/logs', 'mode': 'rw'},  # nosec
             },
         }
         tester.test_docker_image(

--- a/tests/functional/test_pypi_deps.py
+++ b/tests/functional/test_pypi_deps.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2019-2020 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+import os
+import pathlib
+
+import pytest
+
+
+class TestPyPiDependencies:
+    @pytest.mark.usefixtures('_is_image_os')
+    @pytest.mark.parametrize('_is_image_os', ['ubuntu18', 'ubuntu20', 'centos7', 'centos8'], indirect=True)
+    @pytest.mark.xfail(reason='47558 GPL Unidecode PyPi package as dependency for OMZ text_to_speech_demo')
+    def test_gpl_pypi_deps(self, tester, image):
+        root = pathlib.Path(os.path.realpath(__name__)).parent
+        image_folder = image.replace('/', '_').replace(':', '_')
+        pypi_log_folder = root / 'logs' / image_folder / 'pypi_deps'
+        if not pypi_log_folder.exists():
+            pypi_log_folder.mkdir()
+        kwargs = {
+            'volumes': {
+                root / 'tests' / 'resources' / 'pypi_deps': {'bind': '/tmp/pypi_deps', 'mode': 'rw'},
+                pypi_log_folder: {'bind': '/tmp/logs', 'mode': 'rw'},
+            },
+        }
+        tester.test_docker_image(
+            image,
+            ['/bin/bash -ac "python3 -m pip freeze 2>&1 | tee /tmp/logs/pypi_deps.log"',
+             '/bin/bash -ac "python3 -m pip check 2>&1 | tee /tmp/logs/pypi_deps_check.log"',
+             'python3 -m pip install pipdeptree',
+             '/bin/bash -ac "python3 -m pipdeptree -e PyGObject 2>&1 | tee /tmp/logs/pypi_deps_tree.log"',
+             'python3 -m pip install pip-licenses',
+             'pip-licenses --output-file /tmp/logs/pypi_licenses.log',
+             'pip-licenses -f json --output-file /tmp/logs/pypi_licenses.json',
+             'python3 /tmp/pypi_deps/get_gpl_packages.py -f /tmp/logs/pypi_licenses.json '
+             '-l /tmp/logs/pypi_licenses_gpl.json',
+             ],
+            self.test_gpl_pypi_deps.__name__, **kwargs,
+        )
+
+    @pytest.mark.usefixtures('_is_image_os', '_is_distribution')
+    @pytest.mark.parametrize('_is_image_os', ['ubuntu18', 'ubuntu20', 'centos7', 'centos8'], indirect=True)
+    @pytest.mark.parametrize('_is_distribution', ['dev', 'proprietary'], indirect=True)
+    def test_gpl_pypi_deps_venv_tf2(self, tester, image):
+        root = pathlib.Path(os.path.realpath(__name__)).parent
+        image_folder = image.replace('/', '_').replace(':', '_')
+        pypi_log_folder = root / 'logs' / image_folder / 'pypi_deps'
+        if not pypi_log_folder.exists():
+            pypi_log_folder.mkdir()
+        kwargs = {
+            'volumes': {
+                root / 'tests' / 'resources' / 'pypi_deps': {'bind': '/tmp/pypi_deps', 'mode': 'rw'},
+                pypi_log_folder: {'bind': '/tmp/logs', 'mode': 'rw'},
+            },
+        }
+        tester.test_docker_image(
+            image,
+            ['/bin/bash -ac "cd /opt/intel/venv_tf2 && . ./bin/activate && '
+             'python3 -m pip freeze 2>&1 | tee /tmp/logs/pypi_deps_tf2.log"',
+             '/bin/bash -ac "cd /opt/intel/venv_tf2 && . ./bin/activate && '
+             'python3 -m pip check 2>&1 | tee /tmp/logs/pypi_deps_check_tf2.log"',
+             '/bin/bash -ac "cd /opt/intel/venv_tf2 && . ./bin/activate && python3 -m pip install pipdeptree && '
+             'python3 -m pipdeptree -e PyGObject 2>&1 | tee /tmp/logs/pypi_deps_tree_tf2.log"',
+             '/bin/bash -ac "cd /opt/intel/venv_tf2 && . ./bin/activate && python3 -m pip install pip-licenses && '
+             'pip-licenses --output-file /tmp/logs/pypi_licenses_tf2.log && '
+             'pip-licenses -f json --output-file /tmp/logs/pypi_licenses_tf2.json"',
+             'python3 /tmp/pypi_deps/get_gpl_packages.py -f /tmp/logs/pypi_licenses_tf2.json '
+             '-l /tmp/logs/pypi_licenses_gpl_tf2.json',
+             ],
+            self.test_gpl_pypi_deps_venv_tf2.__name__, **kwargs,
+        )

--- a/tests/resources/pypi_deps/get_gpl_packages.py
+++ b/tests/resources/pypi_deps/get_gpl_packages.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2019-2021 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Check GPL/LGPL license for the installed PyPi packages
+"""
+import argparse
+import json
+import logging
+import sys
+
+parser = argparse.ArgumentParser(description='This is GPl/LGPL licenses checker for PyPi packages')
+parser.add_argument(
+    '-f',
+    '--file',
+    metavar='PATH',
+    required=True,
+    help='JSON file with packages meta',
+)
+parser.add_argument(
+    '-l',
+    '--logs',
+    metavar='PATH',
+    required=False,
+    default='pypi_licenses_gpl.json',
+    help='Log file in json format',
+)
+
+logging.basicConfig(level='INFO')
+log = logging.getLogger(__name__)
+log.info('Start searching GPl/LGPL licenses in the installed PyPi packages ...')
+args = parser.parse_args()
+with open(args.file) as licenses_file:
+    pkg_licenses = json.load(licenses_file)
+
+exit_code = 0
+gpl_pkgs = []
+for pkg in pkg_licenses:
+    if 'GPL' in pkg['License']:
+        gpl_pkgs.append(pkg)
+        if 'LGPL' not in pkg['License']:
+            log.error(f'GPL package was found in PyPi environment: {pkg}')
+            exit_code = 1
+log.debug(f'Found GPL/LGPL packages: {gpl_pkgs}')
+with open(args.logs, 'w') as gpl_licenses_file:
+    json.dump(gpl_pkgs, gpl_licenses_file)
+log.info(f'See GPL/LGPL licenses in the json log: {args.logs}')
+
+if exit_code != 0:
+    log.info('FAILED')
+else:
+    log.info('PASSED')
+
+sys.exit(exit_code)


### PR DESCRIPTION
Added two tests to check global(tf1) and venv(tf2) PyPi environments in Linux Docker images. The next step check logs for all images and add downloading LGPL components into Dockerfile. 
Know issue: 47558 will be fixed for 2021.3 release