### PR TITLE
build: remove minor centos version

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ As well you can use available dockerfiles from `<root_project>/dockerfiles/<imag
 ## Supported Operating Systems for Docker image:
  - Ubuntu 18.04 LTS
  - Ubuntu 20.04 LTS
- - CentOS 7.6
- - CentOS 8.2 
- - RHEL 8.2  
+ - CentOS 7
+ - CentOS 8
+ - RHEL 8 
  - Windows Server Core base OS LTSC 2019
 
 ## Prebuilt images

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -12,9 +12,9 @@ You can use Docker CI framework to build an image, please follow [Get Started wi
 ## Supported Operating Systems for Docker image:
  - `ubuntu18` folder (Ubuntu* 18.04 LTS)
  - `ubuntu20` folder (Ubuntu* 20.04 LTS)
- - `centos7` folder (CentOS* 7.6)
- - `centos8` folder (CentOS* 8.2)
- - `rhel8` folder (RHEL* 8.2) 
+ - `centos7` folder (CentOS* 7)
+ - `centos8` folder (CentOS* 8)
+ - `rhel8` folder (RHEL* 8) 
  - `winserver2019` folder (Windows* Server Core base OS LTSC 2019)
 
 ## Supported devices and distributions

--- a/dockerfiles/centos7/openvino_cgvh_runtime_2021.dockerfile
+++ b/dockerfiles/centos7/openvino_cgvh_runtime_2021.dockerfile
@@ -1,6 +1,6 @@
 # Copyright (C) 2019-2021 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-FROM centos:7.6.1810 AS base
+FROM centos:7 AS base
 
 # hadolint ignore=DL3002
 USER root
@@ -74,9 +74,9 @@ RUN ./bootstrap.sh && \
     make -j4
 
 # -----------------
-FROM centos:7.6.1810 AS ov_base
+FROM centos:7 AS ov_base
 
-LABEL Description="This is the runtime image for Intel(R) Distribution of OpenVINO(TM) toolkit on CentOS 7.6"
+LABEL Description="This is the runtime image for Intel(R) Distribution of OpenVINO(TM) toolkit on CentOS 7"
 LABEL Vendor="Intel Corporation"
 
 USER root

--- a/dockerfiles/centos8/openvino_c_runtime_2021.dockerfile
+++ b/dockerfiles/centos8/openvino_c_runtime_2021.dockerfile
@@ -40,7 +40,7 @@ RUN tar -xzf "${TEMP_DIR}"/*.tgz && \
 # -----------------
 FROM centos:8.2.2004 AS ov_base
 
-LABEL Description="This is the runtime image for Intel(R) Distribution of OpenVINO(TM) toolkit on CentOS 8.2"
+LABEL Description="This is the runtime image for Intel(R) Distribution of OpenVINO(TM) toolkit on CentOS 8"
 LABEL Vendor="Intel Corporation"
 
 USER root

--- a/templates/centos7/common/base.dockerfile.j2
+++ b/templates/centos7/common/base.dockerfile.j2
@@ -1,6 +1,6 @@
 # Copyright (C) 2019-2021 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-FROM centos:7.6.1810 AS base
+FROM centos:7 AS base
 
 # hadolint ignore=DL3002
 USER root
@@ -16,9 +16,9 @@ RUN yum update -y && yum install -y curl ca-certificates && \
 {{ pre_command|safe }}
 {% endfor %}
 # -----------------
-FROM centos:7.6.1810 AS ov_base
+FROM centos:7 AS ov_base
 
-LABEL Description="This is the {{ distribution }} image for {{ product_name }} on CentOS 7.6"
+LABEL Description="This is the {{ distribution }} image for {{ product_name }} on CentOS 7"
 LABEL Vendor="Intel Corporation"
 
 USER root

--- a/templates/centos8/common/base.dockerfile.j2
+++ b/templates/centos8/common/base.dockerfile.j2
@@ -18,7 +18,7 @@ RUN yum update -y && yum install -y curl ca-certificates && \
 # -----------------
 FROM centos:8.2.2004 AS ov_base
 
-LABEL Description="This is the {{ distribution }} image for {{ product_name }} on CentOS 8.2"
+LABEL Description="This is the {{ distribution }} image for {{ product_name }} on CentOS 8"
 LABEL Vendor="Intel Corporation"
 
 USER root


### PR DESCRIPTION
Support centos 7.9 by default since 2021.3