### PR TITLE
refactor: move a dependency installation to test script

### DIFF
--- a/dockerfiles/ubuntu18/openvino_c_base_2020.1.dockerfile
+++ b/dockerfiles/ubuntu18/openvino_c_base_2020.1.dockerfile
@@ -60,9 +60,7 @@ RUN echo "source /opt/intel/openvino/bin/setupvars.sh" | tee -a /root/.bashrc
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       curl \
-      ca-certificates \
       g++ \
-      make \
       cmake && \
       rm -rf /var/lib/apt/lists/*
 

--- a/dockerfiles/ubuntu18/openvino_c_base_2020.1.dockerfile
+++ b/dockerfiles/ubuntu18/openvino_c_base_2020.1.dockerfile
@@ -57,6 +57,15 @@ LABEL Vendor="Intel Corporation"
 COPY --from=base /opt/intel /opt/intel
 RUN echo "source /opt/intel/openvino/bin/setupvars.sh" | tee -a /root/.bashrc
 
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      curl \
+      ca-certificates \
+      g++ \
+      make \
+      cmake && \
+      rm -rf /var/lib/apt/lists/*
+
 # Creating user openvino
 RUN useradd -ms /bin/bash -G users openvino && \
     chown openvino -R /home/openvino

--- a/dockerfiles/ubuntu18/openvino_c_base_2020.2.dockerfile
+++ b/dockerfiles/ubuntu18/openvino_c_base_2020.2.dockerfile
@@ -73,9 +73,7 @@ RUN echo "source /opt/intel/openvino/bin/setupvars.sh" | tee -a /root/.bashrc
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       curl \
-      ca-certificates \
       g++ \
-      make \
       cmake && \
       rm -rf /var/lib/apt/lists/*
 

--- a/dockerfiles/ubuntu18/openvino_c_base_2020.2.dockerfile
+++ b/dockerfiles/ubuntu18/openvino_c_base_2020.2.dockerfile
@@ -70,6 +70,15 @@ LABEL Vendor="Intel Corporation"
 COPY --from=base /opt/intel /opt/intel
 RUN echo "source /opt/intel/openvino/bin/setupvars.sh" | tee -a /root/.bashrc
 
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      curl \
+      ca-certificates \
+      g++ \
+      make \
+      cmake && \
+      rm -rf /var/lib/apt/lists/*
+
 # Creating user openvino
 RUN useradd -ms /bin/bash -G users openvino && \
     chown openvino -R /home/openvino

--- a/dockerfiles/ubuntu18/openvino_c_base_2020.3.dockerfile
+++ b/dockerfiles/ubuntu18/openvino_c_base_2020.3.dockerfile
@@ -73,9 +73,7 @@ RUN echo "source /opt/intel/openvino/bin/setupvars.sh" | tee -a /root/.bashrc
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       curl \
-      ca-certificates \
       g++ \
-      make \
       cmake && \
       rm -rf /var/lib/apt/lists/*
 

--- a/dockerfiles/ubuntu18/openvino_c_base_2020.3.dockerfile
+++ b/dockerfiles/ubuntu18/openvino_c_base_2020.3.dockerfile
@@ -70,6 +70,15 @@ LABEL Vendor="Intel Corporation"
 COPY --from=base /opt/intel /opt/intel
 RUN echo "source /opt/intel/openvino/bin/setupvars.sh" | tee -a /root/.bashrc
 
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      curl \
+      ca-certificates \
+      g++ \
+      make \
+      cmake && \
+      rm -rf /var/lib/apt/lists/*
+
 # Creating user openvino
 RUN useradd -ms /bin/bash -G users openvino && \
     chown openvino -R /home/openvino

--- a/dockerfiles/ubuntu18/openvino_c_base_2020.4.dockerfile
+++ b/dockerfiles/ubuntu18/openvino_c_base_2020.4.dockerfile
@@ -65,9 +65,7 @@ RUN echo "source /opt/intel/openvino/bin/setupvars.sh" | tee -a /root/.bashrc
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       curl \
-      ca-certificates \
       g++ \
-      make \
       cmake && \
       rm -rf /var/lib/apt/lists/*
 

--- a/dockerfiles/ubuntu18/openvino_c_base_2020.4.dockerfile
+++ b/dockerfiles/ubuntu18/openvino_c_base_2020.4.dockerfile
@@ -62,6 +62,15 @@ LABEL Vendor="Intel Corporation"
 COPY --from=base /opt/intel /opt/intel
 RUN echo "source /opt/intel/openvino/bin/setupvars.sh" | tee -a /root/.bashrc
 
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      curl \
+      ca-certificates \
+      g++ \
+      make \
+      cmake && \
+      rm -rf /var/lib/apt/lists/*
+
 # Creating user openvino
 RUN useradd -ms /bin/bash -G users openvino && \
     chown openvino -R /home/openvino

--- a/dockerfiles/ubuntu18/openvino_c_base_2021.dockerfile
+++ b/dockerfiles/ubuntu18/openvino_c_base_2021.dockerfile
@@ -67,9 +67,7 @@ RUN echo "source /opt/intel/openvino_2021/bin/setupvars.sh" | tee -a /root/.bash
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       curl \
-      ca-certificates \
       g++ \
-      make \
       cmake && \
       rm -rf /var/lib/apt/lists/*
 

--- a/dockerfiles/ubuntu18/openvino_c_base_2021.dockerfile
+++ b/dockerfiles/ubuntu18/openvino_c_base_2021.dockerfile
@@ -64,6 +64,15 @@ LABEL Vendor="Intel Corporation"
 COPY --from=ov_base /opt/intel /opt/intel
 RUN echo "source /opt/intel/openvino_2021/bin/setupvars.sh" | tee -a /root/.bashrc
 
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      curl \
+      ca-certificates \
+      g++ \
+      make \
+      cmake && \
+      rm -rf /var/lib/apt/lists/*
+
 # Creating user openvino
 RUN useradd -ms /bin/bash -G users openvino && \
     chown openvino -R /home/openvino

--- a/tests/functional/test_base_cpu.py
+++ b/tests/functional/test_base_cpu.py
@@ -10,7 +10,7 @@ import pytest
 @pytest.mark.usefixtures('_is_image_os', '_is_distribution')
 @pytest.mark.parametrize('_is_image_os', [('ubuntu18', 'ubuntu20')], indirect=True)
 @pytest.mark.parametrize('_is_distribution', [('base', 'custom-no-cv')], indirect=True)
-def test_base_cpp(tester, image, install_openvino_dependencies):
+def test_base_cpp(tester, image):
     root = pathlib.Path(os.path.realpath(__name__)).parent
     kwargs = {
         'mem_limit': '3g',
@@ -20,7 +20,6 @@ def test_base_cpp(tester, image, install_openvino_dependencies):
     }
     tester.test_docker_image(
         image,
-        [install_openvino_dependencies,
-         '/bin/bash -ac ". /opt/intel/openvino/bin/setupvars.sh && . /opt/intel/openvino/base_cpu/demo.sh"'],
+        ['/bin/bash -ac ". /opt/intel/openvino/bin/setupvars.sh && . /opt/intel/openvino/base_cpu/demo.sh"'],
         test_base_cpp.__name__, **kwargs,
     )

--- a/tests/resources/base_cpu/demo.sh
+++ b/tests/resources/base_cpu/demo.sh
@@ -4,6 +4,9 @@
 
 export TBB_DIR=${INTEL_OPENVINO_DIR}/deployment_tools/inference_engine/external/tbb/cmake
 
+apt update
+apt install -y --no-install-recommends make ca-certificates
+
 mkdir -p demo/build
 cd demo
 

--- a/tests/resources/base_cpu/demo.sh
+++ b/tests/resources/base_cpu/demo.sh
@@ -2,9 +2,6 @@
 # Copyright (C) 2019-2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-apt update
-apt install -y build-essential curl cmake
-
 export TBB_DIR=${INTEL_OPENVINO_DIR}/deployment_tools/inference_engine/external/tbb/cmake
 
 mkdir -p demo/build
@@ -43,6 +40,6 @@ int main(int argc, char** argv){
 # Build and run the sample
 cd build
 cmake ..
-make -j$(nproc)
+cmake --build .
 ./test_ie
 cd ${INTEL_OPENVINO_DIR}

--- a/tests/resources/base_cpu/demo.sh
+++ b/tests/resources/base_cpu/demo.sh
@@ -2,6 +2,9 @@
 # Copyright (C) 2019-2020 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+apt update
+apt install -y build-essential curl cmake
+
 export TBB_DIR=${INTEL_OPENVINO_DIR}/deployment_tools/inference_engine/external/tbb/cmake
 
 mkdir -p demo/build


### PR DESCRIPTION
this fixes tests on versions younger than 2021.2