### PR TITLE
build: set TF2 as default on ubuntu18 and remove venv_tf2 since 2021.4

### DIFF
--- a/templates/ubuntu18/dist/data_dev.dockerfile.j2
+++ b/templates/ubuntu18/dist/data_dev.dockerfile.j2
@@ -13,7 +13,7 @@ RUN ${PYTHON_VER} -m venv ${VENV_TF2} && \
     pip install --no-cache-dir -U pip==19.3.1 && \
     pip install --no-cache-dir -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_tf2.txt && \
     deactivate
-{% elif build_id > '2021.1' %}
+{% elif build_id > '2021.1' and build_id < '2021.4' %}
 ENV VENV_TF2 /opt/intel/venv_tf2
 
 RUN ${PYTHON_VER} -m venv ${VENV_TF2} && \

--- a/templates/ubuntu18/dist/dev.dockerfile.j2
+++ b/templates/ubuntu18/dist/dev.dockerfile.j2
@@ -4,6 +4,7 @@ WORKDIR /tmp
 RUN ${PYTHON_VER} -m pip install --no-cache-dir cmake && \
     ${PYTHON_VER} -m pip install --no-cache-dir -r ${INTEL_OPENVINO_DIR}/python/${PYTHON_VER}/requirements.txt && \
     find "${INTEL_OPENVINO_DIR}/" -type f \( -name "*requirements.*" -o  -name "*requirements_ubuntu18.*" -o \( -name "*requirements*.in" -and -not -name "*requirements-tensorflow.in" \) \) -not -path "*/accuracy_checker/*" -not -path "*/post_training_optimization_toolkit/*" -not -path "*/python3*/*" -not -path "*/python2*/*" -print -exec ${PYTHON_VER} -m pip install --no-cache-dir -r "{}" \;
+
 {% if '2021.1' in build_id %}
 ENV VENV_TF2 /opt/intel/venv_tf2
 
@@ -12,7 +13,7 @@ RUN ${PYTHON_VER} -m venv ${VENV_TF2} && \
     pip install --no-cache-dir -U pip==19.3.1 && \
     pip install --no-cache-dir -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_tf2.txt && \
     deactivate
-{% elif build_id > '2021.1' %}
+{% elif build_id > '2021.1' and build_id < '2021.4' %}
 ENV VENV_TF2 /opt/intel/venv_tf2
 
 RUN ${PYTHON_VER} -m venv ${VENV_TF2} && \

--- a/templates/ubuntu18/dist/internal_dev.dockerfile.j2
+++ b/templates/ubuntu18/dist/internal_dev.dockerfile.j2
@@ -10,6 +10,7 @@ RUN ${INTEL_OPENVINO_DIR}/install_dependencies/install_openvino_dependencies.sh 
 RUN ${PYTHON_VER} -m pip install --no-cache-dir cmake && \
     ${PYTHON_VER} -m pip install --no-cache-dir -r ${INTEL_OPENVINO_DIR}/python/${PYTHON_VER}/requirements.txt && \
     find "${INTEL_OPENVINO_DIR}/" -type f \( -name "*requirements.*" -o  -name "*requirements_ubuntu18.*" -o \( -name "*requirements*.in" -and -not -name "*requirements-tensorflow.in" \) \) -not -path "*/accuracy_checker/*" -not -path "*/post_training_optimization_toolkit/*" -not -path "*/python3*/*" -not -path "*/python2*/*" -print -exec ${PYTHON_VER} -m pip install --no-cache-dir -r "{}" \;
+
 {% if '2021.1' in build_id %}
 ENV VENV_TF2 /opt/intel/venv_tf2
 
@@ -18,7 +19,7 @@ RUN ${PYTHON_VER} -m venv ${VENV_TF2} && \
     pip install --no-cache-dir -U pip==19.3.1 && \
     pip install --no-cache-dir -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_tf2.txt && \
     deactivate
-{% elif build_id > '2021.1' %}
+{% elif build_id > '2021.1' and build_id < '2021.4' %}
 ENV VENV_TF2 /opt/intel/venv_tf2
 
 RUN ${PYTHON_VER} -m venv ${VENV_TF2} && \

--- a/templates/ubuntu18/dist/proprietary.dockerfile.j2
+++ b/templates/ubuntu18/dist/proprietary.dockerfile.j2
@@ -4,6 +4,7 @@ WORKDIR /tmp
 RUN ${PYTHON_VER} -m pip install --no-cache-dir cmake && \
     ${PYTHON_VER} -m pip install --no-cache-dir -r ${INTEL_OPENVINO_DIR}/python/${PYTHON_VER}/requirements.txt && \
     find "${INTEL_OPENVINO_DIR}/" -type f \( -name "*requirements.*" -o  -name "*requirements_ubuntu18.*" -o \( -name "*requirements*.in" -and -not -name "*requirements-tensorflow.in" \) \) -not -path "*/accuracy_checker/*" -not -path "*/post_training_optimization_toolkit/*" -not -path "*/python3*/*" -not -path "*/python2*/*" -print -exec ${PYTHON_VER} -m pip install --no-cache-dir -r "{}" \;
+
 {% if '2021.1' in build_id %}
 ENV VENV_TF2 /opt/intel/venv_tf2
 
@@ -12,7 +13,7 @@ RUN ${PYTHON_VER} -m venv ${VENV_TF2} && \
     pip install --no-cache-dir -U pip==19.3.1 && \
     pip install --no-cache-dir -r ${INTEL_OPENVINO_DIR}/deployment_tools/model_optimizer/requirements_tf2.txt && \
     deactivate
-{% elif build_id > '2021.1' %}
+{% elif build_id > '2021.1' and build_id < '2021.4' %}
 ENV VENV_TF2 /opt/intel/venv_tf2
 
 RUN ${PYTHON_VER} -m venv ${VENV_TF2} && \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -307,6 +307,14 @@ def _min_product_version(request):
 
 
 @pytest.fixture(scope='session')
+def _max_product_version(request):
+    image_version = request.config.getoption('--product_version')
+    if image_version is not None and request.param < image_version:
+        pytest.skip(f'Test requires the product_version should be {request.param} or older '
+                    f'but get {image_version}')
+
+
+@pytest.fixture(scope='session')
 def _python_ngraph_required(request):
     image = request.config.getoption('--image')
     if request.config.getoption('--image_os') == 'winserver2019':

--- a/tests/functional/demos/test_demos_linux_runtime.py
+++ b/tests/functional/demos/test_demos_linux_runtime.py
@@ -106,7 +106,8 @@ class TestDemosLinuxDataRuntime:
         )
 
     @pytest.mark.hddl
-    @pytest.mark.usefixtures('_python_ngraph_required')
+    @pytest.mark.usefixtures('_python_ngraph_required', '_is_not_image_os')
+    @pytest.mark.parametrize('_is_not_image_os', [('rhel8')], indirect=True)
     @pytest.mark.parametrize('omz_python_demo_path', ['object_detection'], indirect=True)
     def test_detection_ssd_python_hddl(self, tester, image, distribution, dev_root, omz_python_demo_path,
                                        omz_python_demos_requirements_file):
@@ -246,6 +247,8 @@ class TestDemosLinuxRuntime:
         )
 
     @pytest.mark.hddl
+    @pytest.mark.usefixtures('_is_not_image_os')
+    @pytest.mark.parametrize('_is_not_image_os', [('rhel8')], indirect=True)
     @pytest.mark.parametrize('omz_python_demo_path', ['segmentation'], indirect=True)
     def test_segmentation_python_hddl(self, tester, image, distribution, dev_root, omz_python_demo_path,
                                       omz_python_demos_requirements_file):

--- a/tests/functional/samples/test_samples_linux_runtime.py
+++ b/tests/functional/samples/test_samples_linux_runtime.py
@@ -148,6 +148,8 @@ class TestSamplesLinuxRuntime:
         )
 
     @pytest.mark.hddl
+    @pytest.mark.usefixtures('_is_not_image_os')
+    @pytest.mark.parametrize('_is_not_image_os', [('rhel8')], indirect=True)
     def test_hello_classification_cpp_hddl(self, tester, image, dev_root, install_openvino_dependencies):
         kwargs = {
             'devices': ['/dev/ion:/dev/ion'],
@@ -365,6 +367,8 @@ class TestSamplesLinuxRuntime:
         )
 
     @pytest.mark.hddl
+    @pytest.mark.usefixtures('_is_not_image_os')
+    @pytest.mark.parametrize('_is_not_image_os', [('rhel8')], indirect=True)
     def test_hello_reshape_cpp_hddl(self, tester, image, dev_root, install_openvino_dependencies):
         kwargs = {
             'devices': ['/dev/ion:/dev/ion'],
@@ -524,6 +528,8 @@ class TestSamplesLinuxRuntime:
         )
 
     @pytest.mark.hddl
+    @pytest.mark.usefixtures('_is_not_image_os')
+    @pytest.mark.parametrize('_is_not_image_os', [('rhel8')], indirect=True)
     def test_object_detection_cpp_hddl(self, tester, image, dev_root, install_openvino_dependencies):
         kwargs = {
             'devices': ['/dev/ion:/dev/ion'],
@@ -701,6 +707,8 @@ class TestSamplesLinuxRuntime:
         )
 
     @pytest.mark.hddl
+    @pytest.mark.usefixtures('_is_not_image_os')
+    @pytest.mark.parametrize('_is_not_image_os', [('rhel8')], indirect=True)
     def test_classification_async_cpp_hddl(self, tester, image, dev_root, install_openvino_dependencies):
         kwargs = {
             'devices': ['/dev/ion:/dev/ion'],

--- a/tests/functional/test_pypi_deps_linux.py
+++ b/tests/functional/test_pypi_deps_linux.py
@@ -60,8 +60,9 @@ class TestPyPiDependenciesLinux:
             self.test_conflict_pypi_deps.__name__, **kwargs,
         )
 
-    @pytest.mark.usefixtures('_min_product_version', '_is_image_os', '_is_distribution')
+    @pytest.mark.usefixtures('_min_product_version', '_max_product_version', '_is_image_os', '_is_distribution')
     @pytest.mark.parametrize('_min_product_version', ['2021.1'], indirect=True)
+    @pytest.mark.parametrize('_max_product_version', ['2021.3'], indirect=True)
     @pytest.mark.parametrize('_is_image_os', ['ubuntu18'], indirect=True)
     @pytest.mark.parametrize('_is_distribution', [('dev', 'data_dev', 'proprietary')], indirect=True)
     def test_conflict_pypi_deps_venv_tf2(self, tester, image):
@@ -87,8 +88,9 @@ class TestPyPiDependenciesLinux:
             self.test_conflict_pypi_deps_venv_tf2.__name__, **kwargs,
         )
 
-    @pytest.mark.usefixtures('_min_product_version', '_is_image_os', '_is_distribution')
+    @pytest.mark.usefixtures('_min_product_version', '_max_product_version', '_is_image_os', '_is_distribution')
     @pytest.mark.parametrize('_min_product_version', ['2021.1'], indirect=True)
+    @pytest.mark.parametrize('_max_product_version', ['2021.3'], indirect=True)
     @pytest.mark.parametrize('_is_image_os', ['ubuntu18'], indirect=True)
     @pytest.mark.parametrize('_is_distribution', [('dev', 'data_dev', 'proprietary')], indirect=True)
     def test_gpl_pypi_deps_venv_tf2(self, tester, image):


### PR DESCRIPTION
Also disable HDDL tests for rhel8_runtime images