### PR TITLE
enable hadolint check on push events and fix warnings for base dockerfiles

### DIFF
--- a/.github/workflows/hadolint_check.yml
+++ b/.github/workflows/hadolint_check.yml
@@ -1,6 +1,9 @@
 name: Dockerfiles check
 
 on:
+  push:
+    paths:
+      - 'dockerfiles/**/*ockerfile'
   pull_request:
     paths:
       - 'dockerfiles/**/*ockerfile'
@@ -16,9 +19,7 @@ jobs:
         run: |
           set -o pipefail
           has_issues=0
-          url="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${{ github.event.pull_request.number }}/files?per_page=100"
-          files=$(curl -s -X GET -G "$url" | jq -r '.[] | select(.status!="removed") | .filename')
-          for dockerfile in $(echo "$files" | tr '[:space:]' '\n' | grep -P "dockerfiles/.*(\.d|D)ockerfile$")
+          for dockerfile in $(find dockerfiles/ \( -name '*.dockerfile' -o -name 'Dockerfile' \))
           do
             echo "Scanning $dockerfile"
             docker run --rm -i hadolint/hadolint:latest hadolint \

--- a/.github/workflows/hadolint_check.yml
+++ b/.github/workflows/hadolint_check.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           set -o pipefail
           has_issues=0
-          for dockerfile in $(find dockerfiles/ \( -name '*.dockerfile' -o -name 'Dockerfile' \))
+          while IFS= read -r -d '' dockerfile
           do
             echo "Scanning $dockerfile"
             docker run --rm -i hadolint/hadolint:latest hadolint \
@@ -31,7 +31,7 @@ jobs:
             name=$(echo "$dockerfile" | grep -oP '(?<=dockerfiles/).*' | tr / _)
             cp "$dockerfile" "$name"
             cp "$dockerfile".log "${name}.log"
-          done
+          done <  <(find dockerfiles/ \( -name '*.dockerfile' -o -name 'Dockerfile' \) -print0)
           exit "$has_issues"
       - name: Collecting artifacts
         uses: actions/upload-artifact@v2

--- a/dockerfiles/ubuntu18/openvino_c_base_2021.dockerfile
+++ b/dockerfiles/ubuntu18/openvino_c_base_2021.dockerfile
@@ -2,7 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 FROM ubuntu:18.04 as ov_base
 
+# hadolint ignore=DL3002
 USER root
+
+SHELL ["/bin/bash", "-xo", "pipefail", "-c"]
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -25,7 +28,8 @@ RUN curl -o GPG-PUB-KEY-INTEL-OPENVINO-2021 ${PUBLIC_KEY} && \
     rm -rf /var/lib/apt/lists/*
 
 # Install Python and some dependencies for deployment manager
-RUN pip3 install pytest-shutil
+# hadolint ignore=DL3013
+RUN pip3 install --no-cache-dir pytest-shutil
 
 # Create CPU only package
 RUN mkdir openvino_pkg
@@ -58,8 +62,10 @@ RUN rm -r /opt/intel/ && mkdir -p "/opt/intel/openvino_${BUILD_ID}" && \
 
 FROM ubuntu:18.04
 
-LABEL Description="This is the base CPU only image for Intel(R) Distribution of OpenVINO(TM) toolkit on Ubuntu 18.04 LTS"
-LABEL Vendor="Intel Corporation"
+LABEL description="This is the base CPU only image for Intel(R) Distribution of OpenVINO(TM) toolkit on Ubuntu 18.04 LTS"
+LABEL vendor="Intel Corporation"
+
+SHELL ["/bin/bash", "-xo", "pipefail", "-c"]
 
 COPY --from=ov_base /opt/intel /opt/intel
 RUN echo "source /opt/intel/openvino_2021/bin/setupvars.sh" | tee -a /root/.bashrc

--- a/dockerfiles/ubuntu20/openvino_c_base_2021.dockerfile
+++ b/dockerfiles/ubuntu20/openvino_c_base_2021.dockerfile
@@ -2,7 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 FROM ubuntu:20.04 as ov_base
 
+# hadolint ignore=DL3002
 USER root
+
+SHELL ["/bin/bash", "-xo", "pipefail", "-c"]
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -25,7 +28,8 @@ RUN curl -o GPG-PUB-KEY-INTEL-OPENVINO-2021 ${PUBLIC_KEY} && \
     rm -rf /var/lib/apt/lists/*
 
 # Install Python and some dependencies for deployment manager
-RUN pip3 install pytest-shutil
+# hadolint ignore=DL3013
+RUN pip3 install --no-cache-dir pytest-shutil
 
 # Create CPU only package
 RUN mkdir openvino_pkg
@@ -58,8 +62,10 @@ RUN rm -r /opt/intel/ && mkdir -p "/opt/intel/openvino_${BUILD_ID}" && \
 
 FROM ubuntu:20.04
 
-LABEL Description="This is the base CPU only image for Intel(R) Distribution of OpenVINO(TM) toolkit on Ubuntu 20.04 LTS"
-LABEL Vendor="Intel Corporation"
+LABEL description="This is the base CPU only image for Intel(R) Distribution of OpenVINO(TM) toolkit on Ubuntu 20.04 LTS"
+LABEL vendor="Intel Corporation"
+
+SHELL ["/bin/bash", "-xo", "pipefail", "-c"]
 
 COPY --from=ov_base /opt/intel /opt/intel
 


### PR DESCRIPTION
```
-:5 DL3002 warning: Last USER should not be root
-:21 DL4006 warning: Set the SHELL option -o pipefail before RUN with a pipe in it. If you are using /bin/sh in an alpine image or if your shell is symlinked to busybox then consider explicitly setting your SHELL to /bin/ash, or disable this check
-:28 DL3013 warning: Pin versions in pip. Instead of `pip install <package>` use `pip install <package>==<version>` or `pip install --requirement <requirements file>`
-:28 DL3042 warning: Avoid use of cache directory with pip. Use `pip install --no-cache-dir <package>`
-:61 DL3048 style: Invalid label key.
-:62 DL3048 style: Invalid label key.
-:65 DL4006 warning: Set the SHELL option -o pipefail before RUN with a pipe in it. If you are using /bin/sh in an alpine image or if your shell is symlinked to busybox then consider explicitly setting your SHELL to /bin/ash, or disable this check
-:80 DL4006 warning: Set the SHELL option -o pipefail before RUN with a pipe in it. If you are using /bin/sh in an alpine image or if your shell is symlinked to busybox then consider explicitly setting your SHELL to /bin/ash, or disable this check
```