### PR TITLE
test: mark sporadic VPU failures as xfail

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,12 +93,12 @@ def pytest_configure(config):
 def pytest_runtest_makereport(item, call):
     """Mark test as xfailed if caplog contains the specified pattern"""
     outcome = yield
-    xfail_cond_marker = item.get_closest_marker('xfail_log')
-    if call.when == 'call' and xfail_cond_marker:
-        report = outcome.get_result()
-        if report.outcome == 'failed' and xfail_cond_marker.kwargs['pattern'] in report.caplog:
-            report.outcome = 'skipped'
-            report.wasxfail = f"reason: {xfail_cond_marker.kwargs['reason']}"
+    if call.when == 'call':
+        for xfail_cond_marker in item.iter_markers('xfail_log'):
+            report = outcome.get_result()
+            if report.outcome == 'failed' and xfail_cond_marker.kwargs['pattern'] in report.caplog:
+                report.outcome = 'skipped'
+                report.wasxfail = f"reason: {xfail_cond_marker.kwargs['reason']}"
 
 
 def pytest_sessionfinish(session, exitstatus):

--- a/tests/functional/demos/test_demos_linux.py
+++ b/tests/functional/demos/test_demos_linux.py
@@ -54,6 +54,8 @@ class TestDemosLinuxDataDev:
 
     @pytest.mark.vpu
     @pytest.mark.parametrize('omz_python_demo_path', ['action_recognition'], indirect=True)
+    @pytest.mark.xfail_log(pattern='Can not init Myriad device: NC_ERROR',
+                           reason='Sporadic error on MYRIAD device')
     def test_action_recognition_python_vpu(self, tester, image, omz_python_demo_path, product_version):
         kwargs = {'device_cgroup_rules': ['c 189:* rmw'],
                   'volumes': ['/dev/bus/usb:/dev/bus/usb'], 'mem_limit': '3g'}  # nosec # noqa: S108
@@ -126,6 +128,8 @@ class TestDemosLinux:
         )
 
     @pytest.mark.vpu
+    @pytest.mark.xfail_log(pattern='Can not init Myriad device: NC_ERROR',
+                           reason='Sporadic error on MYRIAD device')
     def test_security_vpu(self, tester, image, install_openvino_dependencies):
         kwargs = {'device_cgroup_rules': ['c 189:* rmw'],
                   'volumes': ['/dev/bus/usb:/dev/bus/usb'], 'mem_limit': '3g'}  # nosec # noqa: S108
@@ -168,6 +172,8 @@ class TestDemosLinux:
         )
 
     @pytest.mark.vpu
+    @pytest.mark.xfail_log(pattern='Can not init Myriad device: NC_ERROR',
+                           reason='Sporadic error on MYRIAD device')
     def test_squeezenet_vpu(self, tester, image, install_openvino_dependencies):
         kwargs = {'device_cgroup_rules': ['c 189:* rmw'],
                   'volumes': ['/dev/bus/usb:/dev/bus/usb'], 'mem_limit': '3g'}  # nosec # noqa: S108
@@ -233,6 +239,8 @@ class TestDemosLinux:
         )
 
     @pytest.mark.vpu
+    @pytest.mark.xfail_log(pattern='Can not init Myriad device: NC_ERROR',
+                           reason='Sporadic error on MYRIAD device')
     def test_crossroad_cpp_vpu(self, tester, image, install_openvino_dependencies):
         kwargs = {'device_cgroup_rules': ['c 189:* rmw'],
                   'volumes': ['/dev/bus/usb:/dev/bus/usb'], 'mem_limit': '3g'}  # nosec # noqa: S108
@@ -314,6 +322,8 @@ class TestDemosLinux:
         )
 
     @pytest.mark.vpu
+    @pytest.mark.xfail_log(pattern='Can not init Myriad device: NC_ERROR',
+                           reason='Sporadic error on MYRIAD device')
     def test_text_cpp_vpu(self, tester, image, product_version, install_openvino_dependencies):
         kwargs = {'device_cgroup_rules': ['c 189:* rmw'],
                   'volumes': ['/dev/bus/usb:/dev/bus/usb'], 'mem_limit': '3g'}  # nosec # noqa: S108
@@ -391,6 +401,8 @@ class TestDemosLinux:
     @pytest.mark.vpu
     @pytest.mark.usefixtures('_python_ngraph_required')
     @pytest.mark.parametrize('omz_python_demo_path', ['object_detection'], indirect=True)
+    @pytest.mark.xfail_log(pattern='Can not init Myriad device: NC_ERROR',
+                           reason='Sporadic error on MYRIAD device')
     def test_detection_ssd_python_vpu(self, tester, image, omz_python_demo_path):
         kwargs = {'device_cgroup_rules': ['c 189:* rmw'],
                   'volumes': ['/dev/bus/usb:/dev/bus/usb'], 'mem_limit': '3g'}  # nosec # noqa: S108
@@ -499,6 +511,7 @@ class TestDemosLinux:
 
     @pytest.mark.vpu
     @pytest.mark.parametrize('omz_python_demo_path', ['segmentation'], indirect=True)
+    @pytest.mark.xfail_log(pattern='Can not init Myriad device: NC_ERROR', reason='Sporadic error on MYRIAD device')
     def test_segmentation_python_vpu(self, tester, image, omz_python_demo_path):
         kwargs = {'device_cgroup_rules': ['c 189:* rmw'],
                   'volumes': ['/dev/bus/usb:/dev/bus/usb'], 'mem_limit': '3g'}  # nosec # noqa: S108
@@ -576,6 +589,8 @@ class TestDemosLinux:
     @pytest.mark.vpu
     @pytest.mark.usefixtures('_python_ngraph_required')
     @pytest.mark.parametrize('omz_python_demo_path', ['object_detection'], indirect=True)
+    @pytest.mark.xfail_log(pattern='Can not init Myriad device: NC_ERROR',
+                           reason='Sporadic error on MYRIAD device')
     def test_object_detection_centernet_python_vpu(self, tester, image, omz_python_demo_path):
         kwargs = {'device_cgroup_rules': ['c 189:* rmw'],
                   'volumes': ['/dev/bus/usb:/dev/bus/usb'], 'mem_limit': '3g'}  # nosec # noqa: S108

--- a/tests/functional/demos/test_demos_linux_runtime.py
+++ b/tests/functional/demos/test_demos_linux_runtime.py
@@ -73,6 +73,7 @@ class TestDemosLinuxDataRuntime:
     @pytest.mark.vpu
     @pytest.mark.usefixtures('_python_ngraph_required', '_python_vpu_plugin_required')
     @pytest.mark.parametrize('omz_python_demo_path', ['object_detection'], indirect=True)
+    @pytest.mark.xfail_log(pattern='Can not init Myriad device: NC_ERROR', reason='Sporadic error on MYRIAD device')
     def test_detection_ssd_python_vpu(self, tester, image, distribution, dev_root, omz_python_demo_path,
                                       omz_python_demos_requirements_file):
         kwargs = {
@@ -212,6 +213,7 @@ class TestDemosLinuxRuntime:
     @pytest.mark.vpu
     @pytest.mark.usefixtures('_python_vpu_plugin_required')
     @pytest.mark.parametrize('omz_python_demo_path', ['segmentation'], indirect=True)
+    @pytest.mark.xfail_log(pattern='Can not init Myriad device: NC_ERROR', reason='Sporadic error on MYRIAD device')
     def test_segmentation_python_vpu(self, tester, image, distribution, dev_root, omz_python_demo_path,
                                      omz_python_demos_requirements_file):
         kwargs = {

--- a/tests/functional/samples/test_samples_linux.py
+++ b/tests/functional/samples/test_samples_linux.py
@@ -63,6 +63,7 @@ class TestSamplesLinux:
     @pytest.mark.vpu
     @pytest.mark.xfail_log(pattern='Error: Download',
                            reason='Network problems when downloading alexnet files')
+    @pytest.mark.xfail_log(pattern='Can not init Myriad device: NC_ERROR', reason='Sporadic error on MYRIAD device')
     def test_hello_classification_cpp_vpu(self, tester, image, install_openvino_dependencies):
         kwargs = {'device_cgroup_rules': ['c 189:* rmw'],
                   'volumes': ['/dev/bus/usb:/dev/bus/usb'], 'mem_limit': '3g'}  # nosec # noqa: S108
@@ -181,6 +182,7 @@ class TestSamplesLinux:
         )
 
     @pytest.mark.vpu
+    @pytest.mark.xfail_log(pattern='Can not init Myriad device: NC_ERROR', reason='Sporadic error on MYRIAD device')
     def test_hello_reshape_cpp_vpu(self, tester, image, install_openvino_dependencies):
         kwargs = {'device_cgroup_rules': ['c 189:* rmw'],
                   'volumes': ['/dev/bus/usb:/dev/bus/usb'], 'mem_limit': '3g'}  # nosec # noqa: S108
@@ -265,6 +267,7 @@ class TestSamplesLinux:
         )
 
     @pytest.mark.vpu
+    @pytest.mark.xfail_log(pattern='Can not init Myriad device: NC_ERROR', reason='Sporadic error on MYRIAD device')
     def test_object_detection_cpp_vpu(self, tester, image, install_openvino_dependencies):
         kwargs = {'device_cgroup_rules': ['c 189:* rmw'],
                   'volumes': ['/dev/bus/usb:/dev/bus/usb'], 'mem_limit': '3g'}  # nosec # noqa: S108
@@ -361,6 +364,7 @@ class TestSamplesLinux:
     @pytest.mark.vpu
     @pytest.mark.xfail_log(pattern='Error: Download',
                            reason='Network problems when downloading alexnet files')
+    @pytest.mark.xfail_log(pattern='Can not init Myriad device: NC_ERROR', reason='Sporadic error on MYRIAD device')
     def test_classification_async_cpp_vpu(self, tester, image, install_openvino_dependencies):
         kwargs = {'device_cgroup_rules': ['c 189:* rmw'],
                   'volumes': ['/dev/bus/usb:/dev/bus/usb'], 'mem_limit': '3g'}  # nosec # noqa: S108

--- a/tests/functional/samples/test_samples_linux_runtime.py
+++ b/tests/functional/samples/test_samples_linux_runtime.py
@@ -106,6 +106,7 @@ class TestSamplesLinuxRuntime:
     @pytest.mark.usefixtures('_python_vpu_plugin_required')
     @pytest.mark.xfail_log(pattern='Error: Download',
                            reason='Network problems when downloading alexnet files')
+    @pytest.mark.xfail_log(pattern='Can not init Myriad device: NC_ERROR', reason='Sporadic error on MYRIAD device')
     def test_hello_classification_cpp_vpu(self, tester, image, dev_root, install_openvino_dependencies):
         kwargs = {
             'device_cgroup_rules': ['c 189:* rmw'],
@@ -329,6 +330,7 @@ class TestSamplesLinuxRuntime:
 
     @pytest.mark.vpu
     @pytest.mark.usefixtures('_python_vpu_plugin_required')
+    @pytest.mark.xfail_log(pattern='Can not init Myriad device: NC_ERROR', reason='Sporadic error on MYRIAD device')
     def test_hello_reshape_cpp_vpu(self, tester, image, dev_root, install_openvino_dependencies):
         kwargs = {
             'device_cgroup_rules': ['c 189:* rmw'],
@@ -493,6 +495,7 @@ class TestSamplesLinuxRuntime:
 
     @pytest.mark.vpu
     @pytest.mark.usefixtures('_python_vpu_plugin_required')
+    @pytest.mark.xfail_log(pattern='Can not init Myriad device: NC_ERROR', reason='Sporadic error on MYRIAD device')
     def test_object_detection_cpp_vpu(self, tester, image, dev_root, install_openvino_dependencies):
         kwargs = {
             'device_cgroup_rules': ['c 189:* rmw'],
@@ -671,6 +674,7 @@ class TestSamplesLinuxRuntime:
     @pytest.mark.usefixtures('_python_vpu_plugin_required')
     @pytest.mark.xfail_log(pattern='Error: Download',
                            reason='Network problems when downloading alexnet files')
+    @pytest.mark.xfail_log(pattern='Can not init Myriad device: NC_ERROR', reason='Sporadic error on MYRIAD device')
     def test_classification_async_cpp_vpu(self, tester, image, dev_root, install_openvino_dependencies):
         kwargs = {
             'devices': ['/dev/dri:/dev/dri'],

--- a/tests/functional/test_dl_streamer.py
+++ b/tests/functional/test_dl_streamer.py
@@ -38,7 +38,7 @@ class TestDLStreamerLinux:
         )
 
     @pytest.mark.vpu
-    @pytest.mark.xfail(reason='Failed to construct OpenVINOImageInference. Can not init Myriad device: NC_ERROR.')
+    @pytest.mark.xfail_log(pattern='Can not init Myriad device: NC_ERROR', reason='Sporadic error on MYRIAD device')
     def test_draw_face_attributes_cpp_vpu(self, tester, image, install_openvino_dependencies):
         kwargs = {'device_cgroup_rules': ['c 189:* rmw'],
                   'volumes': ['/dev/bus/usb:/dev/bus/usb'], 'mem_limit': '3g'}  # nosec # noqa: S108


### PR DESCRIPTION
and add support of multiple `xfail_log` markers at same test