### PR TITLE
fix get pypi deps for pot

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You can reuse available Dockerfiles, add your layer and customize the image of O
 * [Available Dockerfiles for OpenVINO™ Deep Learning Workbench](dockerfiles/dl-workbench)
 * [Available Tutorials](docs/tutorials)
 
-As [Docker\*](https://docs.docker.com/) is (mostly) just an isolation tool, the OpenVINO toolkit inside the container is the same as the OpenVINO toolkit installed natively on the host machine, 
+As [Docker\*](https://docs.docker.com/) is (mostly) just an isolation tool, the OpenVINO toolkit inside the container is the same as the OpenVINO toolkit installed natively on the host machine,
 so the [OpenVINO documentation](https://docs.openvinotoolkit.org/) is fully applicable to containerized OpenVINO distribution.
 Additionally, we provide receipts on how to manually build a Docker image with OpenVINO inside both for 
 [Linux](https://docs.openvinotoolkit.org/latest/_docs_install_guides_installing_openvino_docker_linux.html) and [Windows](https://docs.openvinotoolkit.org/latest/_docs_install_guides_installing_openvino_docker_windows.html) containers.
@@ -26,6 +26,7 @@ As well you can use available dockerfiles from `<root_project>/dockerfiles/<imag
  - CentOS 7
  - RHEL 8
  - Windows Server Core base OS LTSC 2019
+ - Windows base OS 20H2
 
 ## Prebuilt images
 
@@ -56,18 +57,22 @@ Components:
 - CentOS: https://hub.docker.com/_/centos
 - Red Hat: https://catalog.redhat.com/software/containers/ubi8/ubi/5c359854d70cc534b3a3784e
 - Windows Server Core base OS: https://hub.docker.com/_/microsoft-windows-servercore
+- Windows base OS: https://hub.docker.com/_/microsoft-windows
 - Intel® Distribution of OpenVINO™ toolkit: https://software.intel.com/en-us/license/eula-for-intel-software-development-products
 
 ## Security guideline
+
 See [SECURITY](./SECURITY.md) guide for details.
 
 ## How to Contribute
+
 See [CONTRIBUTING](./CONTRIBUTING.md) for details. Thank you!
 
 ## Support
+
 Please report questions, issues and suggestions using:
 
-* [GitHub* Issues](https://github.com/openvinotoolkit/docker_ci/issues) 
+* [GitHub* Issues](https://github.com/openvinotoolkit/docker_ci/issues)
 * The [`openvino`](https://stackoverflow.com/questions/tagged/openvino) tag on StackOverflow\*
 * [Forum](https://software.intel.com/en-us/forums/computer-vision)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,7 +61,7 @@ def pytest_configure(config):
         mount_root.mkdir(parents=True, exist_ok=True)
         dev_package_url = package_url.replace('_runtime_', '_dev_')
         # Temporarily, until there is no dev package for these distros
-        if image_os in ('ubuntu20', 'centos7', 'rhel8'):
+        if image_os in ('centos7', 'rhel8'):
             dev_package_url = dev_package_url.replace(image_os, 'ubuntu18')
         if package_url.startswith(('http://', 'https://', 'ftp://')):
             if 'win' in image_os:

--- a/tests/resources/pypi_deps/pypi_deps_manager.py
+++ b/tests/resources/pypi_deps/pypi_deps_manager.py
@@ -56,7 +56,7 @@ def get_pot_dependencies(src: str) -> dict:
         pot_path_str = str(pot_path)
         pot_content['name'] = pot_path_str
         cmd_line = ['python3', pot_path_str, 'egg_info']
-        process = subprocess.run(cmd_line,
+        process = subprocess.run(cmd_line, cwd=pot_path.parent,
                                  stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=False, check=False)  # nosec
         if process.returncode == 0:
             pot_content['content'] = get_pkgs_from_requirement('pot.egg-info/requires.txt')  # type: ignore


### PR DESCRIPTION
after this, we need to update save configs for pypi, it can be done after the first package for 2022.1 R, because we will have such files in jenkins logs.