### PR TITLE
Revert "fix: update path to 97-myriad-usbboot.rules (#236)"

### DIFF
--- a/.github/workflows/images_build_check.yml
+++ b/.github/workflows/images_build_check.yml
@@ -36,7 +36,7 @@ jobs:
         run: python -m pip install -r requirements.txt
       - name: Build Linux image (runtime, latest release)
         if: ${{ matrix.os == 'ubuntu-18.04' && ! startsWith(matrix.image_os, 'win') }}
-        run: python docker_openvino.py build --dist ${{ matrix.image_distribution }} -d cpu -d gpu -d hddl -os ${{ matrix.image_os }} --ocl_release 20.35.17767
+        run: python docker_openvino.py build --dist ${{ matrix.image_distribution }} -os ${{ matrix.image_os }} --ocl_release 20.35.17767
       - name: Build Windows image (runtime, latest release)
         if: ${{ matrix.os == 'windows-2019' && startsWith(matrix.image_os, 'win') }}
         run: python docker_openvino.py build --dist ${{ matrix.image_distribution }} -os ${{ matrix.image_os }}

--- a/templates/ubuntu18/hw/vpu.dockerfile.j2
+++ b/templates/ubuntu18/hw/vpu.dockerfile.j2
@@ -40,5 +40,5 @@ RUN apt-get update && \
 
 WORKDIR /opt/libusb-1.0.22/
 RUN /usr/bin/install -c -m 644 libusb-1.0.pc '/usr/local/lib/pkgconfig' && \
-    cp ${INTEL_OPENVINO_DIR}/install_dependencies/97-myriad-usbboot.rules /etc/udev/rules.d/ && \
+    cp ${INTEL_OPENVINO_DIR}/runtime/3rdparty/97-myriad-usbboot.rules /etc/udev/rules.d/ && \
     ldconfig

--- a/templates/ubuntu20/hw/vpu.dockerfile.j2
+++ b/templates/ubuntu20/hw/vpu.dockerfile.j2
@@ -34,5 +34,5 @@ RUN /bin/mkdir -p '/usr/local/lib' && \
 
 WORKDIR /opt/libusb-1.0.22/
 RUN /usr/bin/install -c -m 644 libusb-1.0.pc '/usr/local/lib/pkgconfig' && \
-    cp ${INTEL_OPENVINO_DIR}/install_dependencies/97-myriad-usbboot.rules /etc/udev/rules.d/ && \
+    cp ${INTEL_OPENVINO_DIR}/runtime/3rdparty/97-myriad-usbboot.rules /etc/udev/rules.d/ && \
     ldconfig


### PR DESCRIPTION
This is required to build image with current format of OV packages.
This reverts commit ec71a4997719dd5449b6165f176616f9d7f9f0a0.