### PR TITLE
Fix rhel8 preflight hasLicense test

### DIFF
--- a/templates/rhel8/common/base.dockerfile.j2
+++ b/templates/rhel8/common/base.dockerfile.j2
@@ -77,7 +77,7 @@ RUN if [ "$INSTALL_SOURCES" = "no" ]; then \
     fi
 
 WORKDIR /licenses
-RUN cp -rf "${INTEL_OPENVINO_DIR}"/licensing /licenses
+RUN cp -rf "${INTEL_OPENVINO_DIR}"/licensing/* /licenses
 
 {% for command in commands %}
 {{ command|safe }}

--- a/templates/rhel8/dist/dev.dockerfile.j2
+++ b/templates/rhel8/dist/dev.dockerfile.j2
@@ -22,6 +22,7 @@ RUN if [ "$INSTALL_SOURCES" = "yes" ]; then \
 WORKDIR ${INTEL_OPENVINO_DIR}/licensing
 RUN curl -L https://raw.githubusercontent.com/openvinotoolkit/docker_ci/master/dockerfiles/rhel8/third-party-programs-docker-runtime.txt --output third-party-programs-docker-runtime.txt && \
     curl -L https://raw.githubusercontent.com/openvinotoolkit/docker_ci/master/dockerfiles/rhel8/third-party-programs-docker-dev.txt --output third-party-programs-docker-dev.txt
+RUN cp third-party-programs-docker-dev.txt third-party-programs-docker-runtime.txt /licenses
 
 
 # Install dependencies needed by OV::RemoteTensor

--- a/templates/rhel8/dist/runtime.dockerfile.j2
+++ b/templates/rhel8/dist/runtime.dockerfile.j2
@@ -1,2 +1,3 @@
 WORKDIR ${INTEL_OPENVINO_DIR}/licensing
 RUN curl -L https://raw.githubusercontent.com/openvinotoolkit/docker_ci/master/dockerfiles/rhel8/third-party-programs-docker-runtime.txt --output third-party-programs-docker-runtime.txt
+RUN cp third-party-programs-docker-runtime.txt /licenses


### PR DESCRIPTION
The file located in a subfolder which failed the test.
Moved the file to the root directory of licenses and added other files to the directory.